### PR TITLE
Move the test environment config to the dummy app

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,13 +1,7 @@
 'use strict';
 
 module.exports = function () {
-  let ENV = {
-    'ember-config-helper': {
-      testData: {
-        field1: 'test',
-      },
-    },
-  };
+  let ENV = {};
 
   return ENV;
 };

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -21,6 +21,12 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+
+    'ember-config-helper': {
+      testData: {
+        field1: 'test',
+      },
+    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
An addon's `config/environment.js` file is combined with the parent app's environment config.

Closes #2 