### PR TITLE
Drop support for Ember < v5.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Gaining access to an app's config file from a template only route or component c
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.24 or above
-* Ember CLI v3.24 or above
+* Ember.js v5.12 or above
+* Ember CLI v5.12 or above
 * Node.js v12 or above
 
 


### PR DESCRIPTION
Older versions should still work but aren't explicitly tested.

v5.12 is EOL as well but is still used quite a bit by our apps.